### PR TITLE
Automatically create outputs directory in tools/asset_grid.py

### DIFF
--- a/worldgen/tools/asset_grid.py
+++ b/worldgen/tools/asset_grid.py
@@ -258,7 +258,7 @@ def main(args):
     import_surface_registry()
     name = '_'.join(args.factories)
     path = Path(os.getcwd()) / 'outputs' / name
-    path.mkdir(exist_ok=True)
+    path.mkdir(parents=True, exist_ok=True)
 
     if args.gpu:
         enable_gpu()


### PR DESCRIPTION
tools/asset_grid.py would crash if the outputs directory does not exist. Changed the script to automatically create the outputs directory in case it does not exist.